### PR TITLE
Add code and documentation style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ By making a contribution to this project, I certify that:
     involved.'
 ```
 
-## DCO Sign-Off Methods
+### Usage of DCO Sign-Off
 
 The DCO requires a sign-off message in the following format appear on each commit in the pull request:
 
@@ -65,8 +65,23 @@ fi
 
 Placing this script into a file called `.git/hooks/commit-msg` and making it executable (e.g. using `chmod a+x .git/hooks/commit-msg` on unixoid operating systems) will prevent commits without a sign-off.
 
-## Commit signature verification
+## GPG Commit Signature Verification
 
-The project requires a verification of the commit signature using GPG-sign commits with `-S [<keyid>]`. The `keyid` argument is optional and defaults to the committer identity; if specified, it must be stuck to the option without a space. `--no-gpg-sign` is useful to countermand both `commit.gpgSign` configuration variable, and earlier `--gpg-sign`.
+Every commit in a repository of OpenMSL requires a verification of the commit signature using GPG-sign commits with `-S [<keyid>]`. The `keyid` argument is optional and defaults to the committer identity; if specified, it must be stuck to the option without a space. `--no-gpg-sign` is useful to countermand both `commit.gpgSign` configuration variable, and earlier `--gpg-sign`.
 
 You can read all about setting it up in the [official GitHub documentation](https://docs.github.com/en/authentication/managing-commit-signature-verification).
+
+Using DCO, GPG and a custom commit message, your commit command reads e.g.
+```bash
+git commit -s -S -m "Your commit message"
+```
+
+## Code und Documentation Style
+
+To maintain clean and consistent code and documentation, general style guidelines are to be followed. These guidelines depend on the utilized coding or markup language.
+
+### C++
+For C++ code clang-format and clang-tidy have to be used. There is no general format set for OpenMSL, it can be customized for every repository. You can find an example for respective clang-format and clang-tidy files in the [template repository of sl-1](https://github.com/openMSL/sl-1-0-sensor-model-repository-template). The code style of C++ files will be checked against these config files in the CI pipeline of the repository.
+
+### Markdown
+For readmes and other documentation written in Markdown, [these rules](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md) are used as a guideline. Similar to C++ these rules can be adapted to the needs of the individual repository with a markdownlint.json file. You can find an example [here](https://github.com/openMSL/sl-1-0-sensor-model-repository-template/blob/main/.github/workflows/markdownlint.json). The style of all .md files will be checked against these config file in the CI pipeline of the repository.


### PR DESCRIPTION
**Reference to a related issue in the repository**
#9 

**Add a description**
In SL-1 certain style rules are enforced by the CI pipeline. Therefore, these rules should be explained in the contributing documentation. These are general rules for code and documentation styles, that do not only apply to sensor models.

**Take this checklist as orientation for yourself, if this PR is ready for Maintainer Review**
- [x] My suggestion follows the [governance rules](https://github.com/openMSL/governance-and-documentation).
- [x] All commits of this PR are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] My changes generate no errors when passing CI tests. 
- [x] I updated all documentation (readmes incl. figures) according to my changes.
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.
