### PR TITLE
Fix link to network proxy in readme

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -112,7 +112,7 @@ Initiated: Call for participation. Get engaged [hello@envited.market](mailto:hel
 
 - [sl-5-1-srmd-validator](https://github.com/openMSL/sl-5-1-srmd-validator)
 - [sl-5-2-osi-field-checker](https://github.com/openMSL/sl-5-2-osi-field-checker)
-- [sl-5-3-osmp-network-proxy](sl-5-3-osmp-network-proxy)
+- [sl-5-3-osmp-network-proxy](https://github.com/openMSL/sl-5-3-osmp-network-proxy)
 - [sl-5-4-standalone-osi-trace-file-player](https://github.com/openMSL/sl-5-4-standalone-osi-trace-file-player)
 - [sl-5-5-osi-trace-file-player](https://github.com/openMSL/sl-5-5-osi-trace-file-player)
 - [sl-5-6-osi-trace-file-writer](https://github.com/openMSL/sl-5-6-osi-trace-file-writer)


### PR DESCRIPTION
**Add a description**
The link to the network proxy repo is not working. This fixes it.

**Take this checklist as orientation for yourself, if this PR is ready for Maintainer Review**
- [x] My suggestion follows the [governance rules](https://github.com/openMSL/governance-and-documentation).
- [x] All commits of this PR are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits).
- [x] My changes generate no errors when passing CI tests. 
- [x] I updated all documentation (readmes incl. figures) according to my changes.
- [x] I have successfully implemented and tested my fix/feature locally.
- [x] Appropriate reviewer(s) are assigned.
